### PR TITLE
fix(itemlist-view): Process flimit as getInt integer

### DIFF
--- a/plg_k2filter/K2Filter/views/itemlist/view.html.php
+++ b/plg_k2filter/K2Filter/views/itemlist/view.html.php
@@ -334,7 +334,7 @@ class K2ViewItemlist extends K2View {
 		// Set limit for model
 		if (!$limit) $limit = 10;
 		
-		if(JRequest::getInt("flimit") != "") {
+		if((int)JRequest::getInt("flimit") > 0) {
 			$limit = JRequest::getInt("flimit");
 			if ($filter_template == 2) {
 				//$params->set('num_primary_items', $limit);


### PR DESCRIPTION
Hi,

I'm finding that on PHP 8 `JRequest::getInt` is actually returning an integer and the `$limit` is set to 0.

This fix corrects the issue.

Thanks,
Anibal